### PR TITLE
Add a condition on the PartitionKey index to query when possible

### DIFF
--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/azureconnectors/AzureTableConnector.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/azureconnectors/AzureTableConnector.java
@@ -56,6 +56,20 @@ public class AzureTableConnector {
                 TableQuery.Operators.AND,
                 toDateCondition);
 
+        // Adding a condition on the PartitionKey index when we can gives a huge performance boost
+        if (fromDate.get(Calendar.YEAR) == toDate.get(Calendar.YEAR)) {
+            String yearCondition = TableQuery.generateFilterCondition(
+                    AirDataEntityColumns.PARTITION_KEY,
+                    TableQuery.QueryComparisons.EQUAL,
+                    Integer.toString(fromDate.get(Calendar.YEAR))
+            );
+            filterCondition = TableQuery.combineFilters(
+                    yearCondition,
+                    TableQuery.Operators.AND,
+                    filterCondition
+            );
+        }
+
         TableQuery<entityClass> query =
                 TableQuery.from(classToMapByReflection)
                           .where(filterCondition);

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/entities/DataEntityColumns.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/entities/DataEntityColumns.java
@@ -5,6 +5,7 @@ package uk.ac.cam.alpha2017.airqualityradar.backend.data.entities;
  */
 public interface DataEntityColumns {
     String ROW_KEY = "RowKey";
+    String PARTITION_KEY = "PartitionKey";
 
     /**
      * The year, formatted as a 4-digit number


### PR DESCRIPTION
This gives a huge performance boost when fetching entities between two dates in the same year.