### PR TITLE
Implement PredictionDataProvider

### DIFF
--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/ApplicationConfig.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/ApplicationConfig.java
@@ -3,6 +3,7 @@ package uk.ac.cam.alpha2017.airqualityradar.backend;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.ac.cam.alpha2017.airqualityradar.backend.data.HistoricalDataProvider;
+import uk.ac.cam.alpha2017.airqualityradar.backend.data.PredictionsDataProvider;
 import uk.ac.cam.alpha2017.airqualityradar.backend.data.azureconnectors.AzureTableConnector;
 import uk.ac.cam.alpha2017.airqualityradar.backend.data.credentials.StorageConnectionInfo;
 import uk.ac.cam.alpha2017.airqualityradar.backend.data.credentials.StorageCredentials;
@@ -22,12 +23,17 @@ public class ApplicationConfig {
 
     @Bean
     public DataService dataService() {
-        return new RadarDataService(historicalDataProvider());
+        return new RadarDataService(historicalDataProvider(), predictionsDataProvider());
     }
 
     @Bean
     public HistoricalDataProvider historicalDataProvider() {
         return new HistoricalDataProvider(azureTableConnector(), dataPointConverter());
+    }
+
+    @Bean
+    public PredictionsDataProvider predictionsDataProvider() {
+        return new PredictionsDataProvider(azureTableConnector(), dataPointConverter());
     }
 
     @Bean

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/AbstractDataProvider.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/AbstractDataProvider.java
@@ -12,12 +12,9 @@ import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.util.*;
 
-/**
- * Created by jirka on 5.3.17.
- */
 public abstract class AbstractDataProvider {
-    protected final AzureTableConnector connector;
-    protected final DataPointConverter dataPointConverter;
+    private final AzureTableConnector connector;
+    private final DataPointConverter dataPointConverter;
 
     public AbstractDataProvider(AzureTableConnector connector, DataPointConverter dataPointConverter) {
         this.connector = connector;
@@ -25,12 +22,12 @@ public abstract class AbstractDataProvider {
     }
 
     /**
-     * Gets a historical data points from the collection of historical data on Azure for
+     * Gets data points from the specified collections of historical and weather data on Azure for
      * each of the specified date/times, at each of the specified locations
      *
      * @param fromCalendar The date and time to start return data points from
      * @param toCalendar   The date and time that we will not return data points after
-     * @return The data points from the historical data per calendar per location
+     * @return The data points from the data per calendar per location
      */
     public List<DataPoint> getDataPoints(Calendar fromCalendar, Calendar toCalendar) throws StorageException, InvalidKeyException, URISyntaxException, TableDoesNotExistException {
         ArrayList<AirDataEntity> airDataResultList = new ArrayList<>();
@@ -44,11 +41,11 @@ public abstract class AbstractDataProvider {
     }
 
     /**
-     * Maps historical air quality data with historical weather data (both retrieved from Azure)
+     * Maps air quality data and weather data (both retrieved from Azure) to DataPoints
      *
-     * @param weatherDataResultList A list of historical weather data retrived from Azure. ArrayList required for fast sorting.
-     * @param airDataResultList     A list of historical air quality data retrived from Azure. ArrayList required for fast sorting.
-     * @return The data points including both weather and air quality from the historical data per calendar per location
+     * @param weatherDataResultList A list of weather data retrieved from Azure. ArrayList required for fast sorting.
+     * @param airDataResultList     A list of air quality data retrieved from Azure. ArrayList required for fast sorting.
+     * @return The data points including both weather and air quality from the data per calendar per location
      */
     private ArrayList<DataPoint> mapDataPoints(List<WeatherDataEntity> weatherDataResultList, List<AirDataEntity> airDataResultList) {
         // Sort lists & convert to iterables
@@ -80,7 +77,7 @@ public abstract class AbstractDataProvider {
                     }
                 }
             }
-            dataPoints.add(dataPointConverter.convertAirAndWeatherToDataPoint(currentAirDataEntity, currentWeatherEntity));
+            dataPoints.add(dataPointConverter.convertAirAndWeatherToDataPoint(currentAirDataEntity, currentWeatherEntity, isPredicted()));
         }
 
         return dataPoints;
@@ -88,5 +85,6 @@ public abstract class AbstractDataProvider {
 
     abstract String getAirDataTableName();
     abstract String getWeatherDataTableName();
+    abstract boolean isPredicted();
 
 }

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/AbstractDataProvider.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/AbstractDataProvider.java
@@ -1,0 +1,92 @@
+package uk.ac.cam.alpha2017.airqualityradar.backend.data;
+
+import com.microsoft.azure.storage.StorageException;
+import uk.ac.cam.alpha2017.airqualityradar.backend.data.azureconnectors.AzureTableConnector;
+import uk.ac.cam.alpha2017.airqualityradar.backend.data.azureconnectors.TableDoesNotExistException;
+import uk.ac.cam.alpha2017.airqualityradar.backend.data.dataconverters.DataPointConverter;
+import uk.ac.cam.alpha2017.airqualityradar.backend.data.entities.AirDataEntity;
+import uk.ac.cam.alpha2017.airqualityradar.backend.data.entities.WeatherDataEntity;
+import uk.ac.cam.alpha2017.airqualityradar.backend.models.DataPoint;
+
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.util.*;
+
+/**
+ * Created by jirka on 5.3.17.
+ */
+public abstract class AbstractDataProvider {
+    protected final AzureTableConnector connector;
+    protected final DataPointConverter dataPointConverter;
+
+    public AbstractDataProvider(AzureTableConnector connector, DataPointConverter dataPointConverter) {
+        this.connector = connector;
+        this.dataPointConverter = dataPointConverter;
+    }
+
+    /**
+     * Gets a historical data points from the collection of historical data on Azure for
+     * each of the specified date/times, at each of the specified locations
+     *
+     * @param fromCalendar The date and time to start return data points from
+     * @param toCalendar   The date and time that we will not return data points after
+     * @return The data points from the historical data per calendar per location
+     */
+    public List<DataPoint> getDataPoints(Calendar fromCalendar, Calendar toCalendar) throws StorageException, InvalidKeyException, URISyntaxException, TableDoesNotExistException {
+        ArrayList<AirDataEntity> airDataResultList = new ArrayList<>();
+        ArrayList<WeatherDataEntity> weatherDataResultList = new ArrayList<>();
+
+        // Convert iterators to list using Java8 syntactic sugar & lambdas <3
+        connector.getEntitiesBetweenCalendars(getAirDataTableName(), fromCalendar, toCalendar, AirDataEntity.class).forEachRemaining(airDataResultList::add);
+        connector.getEntitiesBetweenCalendars(getWeatherDataTableName(), fromCalendar, toCalendar, WeatherDataEntity.class).forEachRemaining(weatherDataResultList::add);
+
+        return mapDataPoints(weatherDataResultList, airDataResultList);
+    }
+
+    /**
+     * Maps historical air quality data with historical weather data (both retrieved from Azure)
+     *
+     * @param weatherDataResultList A list of historical weather data retrived from Azure. ArrayList required for fast sorting.
+     * @param airDataResultList     A list of historical air quality data retrived from Azure. ArrayList required for fast sorting.
+     * @return The data points including both weather and air quality from the historical data per calendar per location
+     */
+    private ArrayList<DataPoint> mapDataPoints(List<WeatherDataEntity> weatherDataResultList, List<AirDataEntity> airDataResultList) {
+        // Sort lists & convert to iterables
+        Collections.sort(airDataResultList);
+        Collections.sort(weatherDataResultList);
+        Iterator<AirDataEntity> airDataEntityIterator = airDataResultList.iterator();
+        Iterator<WeatherDataEntity> weatherDataEntityIterator = weatherDataResultList.iterator();
+
+        // Setup
+        WeatherDataEntity currentWeatherEntity = null;
+        if (weatherDataEntityIterator.hasNext()) {
+            currentWeatherEntity =  weatherDataEntityIterator.next();
+        }
+        AirDataEntity currentAirDataEntity;
+        ArrayList<DataPoint> dataPoints = new ArrayList<>(airDataResultList.size());
+
+        while (airDataEntityIterator.hasNext()) {
+            currentAirDataEntity = airDataEntityIterator.next();
+            if (weatherDataEntityIterator.hasNext()) {
+                // If weather entity is newer than air data entity, go through the list to find one that's not
+                while (currentAirDataEntity.getSearchTimestamp().compareTo(currentWeatherEntity.getSearchTimestamp()) > 0) {
+                    // If no more weather results just connect all remaining air data points with null
+                    if (!(weatherDataEntityIterator.hasNext())) {
+                        currentWeatherEntity = null;
+                        break;
+                    } else {
+                        // else go on traversing the list until you find an up to date point
+                        currentWeatherEntity = weatherDataEntityIterator.next();
+                    }
+                }
+            }
+            dataPoints.add(dataPointConverter.convertAirAndWeatherToDataPoint(currentAirDataEntity, currentWeatherEntity));
+        }
+
+        return dataPoints;
+    }
+
+    abstract String getAirDataTableName();
+    abstract String getWeatherDataTableName();
+
+}

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/HistoricalDataProvider.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/HistoricalDataProvider.java
@@ -19,4 +19,9 @@ public class HistoricalDataProvider extends AbstractDataProvider {
     String getWeatherDataTableName() {
         return "weather";
     }
+
+    @Override
+    boolean isPredicted() {
+        return false;
+    }
 }

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/HistoricalDataProvider.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/HistoricalDataProvider.java
@@ -1,87 +1,22 @@
 package uk.ac.cam.alpha2017.airqualityradar.backend.data;
 
-import com.microsoft.azure.storage.StorageException;
 import uk.ac.cam.alpha2017.airqualityradar.backend.data.azureconnectors.AzureTableConnector;
-import uk.ac.cam.alpha2017.airqualityradar.backend.data.azureconnectors.TableDoesNotExistException;
 import uk.ac.cam.alpha2017.airqualityradar.backend.data.dataconverters.DataPointConverter;
-import uk.ac.cam.alpha2017.airqualityradar.backend.data.entities.AirDataEntity;
-import uk.ac.cam.alpha2017.airqualityradar.backend.data.entities.WeatherDataEntity;
-import uk.ac.cam.alpha2017.airqualityradar.backend.models.DataPoint;
 
-import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
-import java.util.*;
-
-public class HistoricalDataProvider {
-    private static final String HISTORICAL_AIR_DATA_TABLE_NAME = "pollution";
-    private static final String HISTORICAL_WEATHER_DATA_TABLE_NAME = "weather";
-    private final AzureTableConnector connector;
-    private final DataPointConverter dataPointConverter;
+public class HistoricalDataProvider extends AbstractDataProvider {
 
     public HistoricalDataProvider(AzureTableConnector connector, DataPointConverter dataPointConverter) {
-        this.connector = connector;
-        this.dataPointConverter = dataPointConverter;
+        super(connector, dataPointConverter);
     }
 
-    /**
-     * Gets a historical data points from the collection of historical data on Azure for
-     * each of the specified date/times, at each of the specified locations
-     *
-     * @param fromCalendar The date and time to start return data points from
-     * @param toCalendar   The date and time that we will not return data points after
-     * @return The data points from the historical data per calendar per location
-     */
-    public List<DataPoint> getDataPoints(Calendar fromCalendar, Calendar toCalendar) throws StorageException, InvalidKeyException, URISyntaxException, TableDoesNotExistException {
-        ArrayList<AirDataEntity> airDataResultList = new ArrayList<>();
-        ArrayList<WeatherDataEntity> weatherDataResultList = new ArrayList<>();
-
-        // Convert iterators to list using Java8 syntactic sugar & lambdas <3
-        connector.getEntitiesBetweenCalendars(HISTORICAL_AIR_DATA_TABLE_NAME, fromCalendar, toCalendar, AirDataEntity.class).forEachRemaining(airDataResultList::add);
-        connector.getEntitiesBetweenCalendars(HISTORICAL_WEATHER_DATA_TABLE_NAME, fromCalendar, toCalendar, WeatherDataEntity.class).forEachRemaining(weatherDataResultList::add);
-
-        return mapDataPoints(weatherDataResultList, airDataResultList);
+    @Override
+    String getAirDataTableName() {
+        return "pollution";
     }
 
-    /**
-     * Maps historical air quality data with historical weather data (both retrieved from Azure)
-     *
-     * @param weatherDataResultList A list of historical weather data retrived from Azure. ArrayList required for fast sorting.
-     * @param airDataResultList     A list of historical air quality data retrived from Azure. ArrayList required for fast sorting.
-     * @return The data points including both weather and air quality from the historical data per calendar per location
-     */
-    private ArrayList<DataPoint> mapDataPoints(List<WeatherDataEntity> weatherDataResultList, List<AirDataEntity> airDataResultList) {
-        // Sort lists & convert to iterables
-        Collections.sort(airDataResultList);
-        Collections.sort(weatherDataResultList);
-        Iterator<AirDataEntity> airDataEntityIterator = airDataResultList.iterator();
-        Iterator<WeatherDataEntity> weatherDataEntityIterator = weatherDataResultList.iterator();
 
-        // Setup
-        WeatherDataEntity currentWeatherEntity = null;
-        if (weatherDataEntityIterator.hasNext()) {
-            currentWeatherEntity =  weatherDataEntityIterator.next();
-        }
-        AirDataEntity currentAirDataEntity;
-        ArrayList<DataPoint> dataPoints = new ArrayList<>(airDataResultList.size());
-
-        while (airDataEntityIterator.hasNext()) {
-            currentAirDataEntity = airDataEntityIterator.next();
-            if (weatherDataEntityIterator.hasNext()) {
-                // If weather entity is newer than air data entity, go through the list to find one that's not
-                while (currentAirDataEntity.getSearchTimestamp().compareTo(currentWeatherEntity.getSearchTimestamp()) > 0) {
-                    // If no more weather results just connect all remaining air data points with null
-                    if (!(weatherDataEntityIterator.hasNext())) {
-                        currentWeatherEntity = null;
-                        break;
-                    } else {
-                        // else go on traversing the list until you find an up to date point
-                        currentWeatherEntity = weatherDataEntityIterator.next();
-                    }
-                }
-            }
-            dataPoints.add(dataPointConverter.convertAirAndWeatherToDataPoint(currentAirDataEntity, currentWeatherEntity));
-        }
-
-        return dataPoints;
+    @Override
+    String getWeatherDataTableName() {
+        return "weather";
     }
 }

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/PredictionsDataProvider.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/PredictionsDataProvider.java
@@ -10,12 +10,16 @@ public class PredictionsDataProvider extends AbstractDataProvider {
 
     @Override
     String getAirDataTableName() {
-        return "predictions";
+        return "prediction";
     }
 
     @Override
     String getWeatherDataTableName() {
-        //TODO: Add weather table name
-        return null;
+        return "forecast";
+    }
+
+    @Override
+    boolean isPredicted() {
+        return true;
     }
 }

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/PredictionsDataProvider.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/PredictionsDataProvider.java
@@ -1,25 +1,21 @@
 package uk.ac.cam.alpha2017.airqualityradar.backend.data;
 
-import uk.ac.cam.alpha2017.airqualityradar.backend.models.DataPoint;
-import uk.ac.cam.alpha2017.airqualityradar.backend.models.Location;
-import uk.ac.cam.alpha2017.airqualityradar.backend.models.WeatherDataPoint;
+import uk.ac.cam.alpha2017.airqualityradar.backend.data.azureconnectors.AzureTableConnector;
+import uk.ac.cam.alpha2017.airqualityradar.backend.data.dataconverters.DataPointConverter;
 
-import java.util.Calendar;
-import java.util.List;
-import java.util.Map;
+public class PredictionsDataProvider extends AbstractDataProvider {
+    public PredictionsDataProvider(AzureTableConnector connector, DataPointConverter dataPointConverter) {
+        super(connector, dataPointConverter);
+    }
 
-public class PredictionsDataProvider {
+    @Override
+    String getAirDataTableName() {
+        return "predictions";
+    }
 
-    /**
-     * Gets predictions from the ML model for each of the locations at each of the specified times,
-     * given the weather forecasts at those times
-     *
-     * @param forecasts A map of date/times we wish to get the prediction for and the
-     *                  associated weather forecast at that date/time
-     * @param locations The locations at which we are requesting predictions
-     * @return The data points predicted by the ML model per calendar per location
-     */
-    public List<DataPoint> getPredictions(Map<Calendar, WeatherDataPoint> forecasts, List<Location> locations) {
+    @Override
+    String getWeatherDataTableName() {
+        //TODO: Add weather table name
         return null;
     }
 }

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/azureconnectors/AzureTableConnector.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/azureconnectors/AzureTableConnector.java
@@ -4,11 +4,14 @@ import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.table.CloudTable;
 import com.microsoft.azure.storage.table.CloudTableClient;
+import com.microsoft.azure.storage.table.EntityResolver;
 import com.microsoft.azure.storage.table.TableQuery;
 import com.microsoft.azure.storage.table.TableServiceEntity;
 import uk.ac.cam.alpha2017.airqualityradar.backend.data.credentials.StorageConnectionInfo;
 import uk.ac.cam.alpha2017.airqualityradar.backend.data.dataconverters.CalendarConverter;
+import uk.ac.cam.alpha2017.airqualityradar.backend.data.entities.AirDataEntity;
 import uk.ac.cam.alpha2017.airqualityradar.backend.data.entities.AirDataEntityColumns;
+import uk.ac.cam.alpha2017.airqualityradar.backend.data.entities.AirDataEntityResolver;
 
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
@@ -74,7 +77,13 @@ public class AzureTableConnector {
                 TableQuery.from(classToMapByReflection)
                           .where(filterCondition);
 
-        Iterable<entityClass> entityIterable = cloudTable.execute(query);
+        Iterable<entityClass> entityIterable;
+
+        if (classToMapByReflection == AirDataEntity.class) {
+            entityIterable = cloudTable.execute(query, (EntityResolver<entityClass>) new AirDataEntityResolver());
+        } else {
+            entityIterable = cloudTable.execute(query);
+        }
 
         return entityIterable.iterator();
     }

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/dataconverters/DataPointConverter.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/dataconverters/DataPointConverter.java
@@ -12,14 +12,14 @@ import java.text.ParseException;
 import java.util.Calendar;
 
 public class DataPointConverter {
-    private final static int locationScalingFactor = 1000000; //1 million
+    private final static int locationScalingFactor = 1000000; // 1 million
 
     /**
      * Creates a DataPoint from an air and weather entity
      *
      * @return The data point corresponding to these entities
      */
-    public DataPoint convertAirAndWeatherToDataPoint(AirDataEntity airDataEntity, WeatherDataEntity weatherDataEntity) {
+    public DataPoint convertAirAndWeatherToDataPoint(AirDataEntity airDataEntity, WeatherDataEntity weatherDataEntity, boolean isPredicted) {
         Calendar calendar;
 
         try {
@@ -28,7 +28,12 @@ public class DataPointConverter {
             throw new RuntimeException("Failed to parse search timestamp in entity");
         }
 
-        Location location = new Location(airDataEntity.getLatitude().doubleValue() / locationScalingFactor, airDataEntity.getLongitude().doubleValue() / locationScalingFactor);
+        Location location = null;
+
+        if (airDataEntity.getLatitude() != null && airDataEntity.getLongitude() != null) {
+            location = new Location(airDataEntity.getLatitude().doubleValue() / locationScalingFactor, airDataEntity.getLongitude().doubleValue() / locationScalingFactor);
+        }
+
         AirDataPoint airDataPoint = convertAirToDataPoint(airDataEntity);
         WeatherDataPoint weatherDataPoint;
 
@@ -39,24 +44,35 @@ public class DataPointConverter {
             weatherDataPoint = convertWeatherToDataPoint(weatherDataEntity);
         }
 
-        return new DataPoint(calendar, location, airDataPoint, weatherDataPoint);
+        return new DataPoint(calendar, location, airDataPoint, weatherDataPoint, isPredicted);
     }
 
     private AirDataPoint convertAirToDataPoint (AirDataEntity airDataEntity) {
-        NOxMeasurement NOx = airDataEntity.getNOx().equals("") ? null : new NOxMeasurement(Double.parseDouble(airDataEntity.getNOx()));
-        PM10Measurement PM10 = airDataEntity.getPM10().equals("") ? null : new PM10Measurement(Double.parseDouble(airDataEntity.getPM10()));
-        PM25Measurement PM25 = airDataEntity.getPM25().equals("") ? null : new PM25Measurement(Double.parseDouble(airDataEntity.getPM25()));
+        NOxMeasurement NOx = airDataEntity.getNOx() == null ? null : new NOxMeasurement(airDataEntity.getNOx());
+        PM10Measurement PM10 = airDataEntity.getPM10() == null ? null : new PM10Measurement(airDataEntity.getPM10());
+        PM25Measurement PM25 = airDataEntity.getPM25() == null ? null : new PM25Measurement(airDataEntity.getPM25());
 
         return new AirDataPoint(NOx, PM10, PM25);
     }
 
     private WeatherDataPoint convertWeatherToDataPoint(WeatherDataEntity weatherDataEntity) {
-        TemperatureMeasurement temperatureMeasurement = weatherDataEntity.getTemperature().equals("") ? null : new TemperatureMeasurement(Double.parseDouble(weatherDataEntity.getTemperature()));
-        HumidityMeasurement humidityMeasurement = weatherDataEntity.getHumidity().equals("") ? null : new HumidityMeasurement(Double.parseDouble(weatherDataEntity.getHumidity()));
-        WindDirectionMeasurement windDirectionMeasurement = weatherDataEntity.getWindDirection().equals("") ? null : new WindDirectionMeasurement(weatherDataEntity.getWindDirection());
-        WindSpeedMeasurement windSpeedMeasurement = weatherDataEntity.getWindSpeed().equals("") ? null : new WindSpeedMeasurement(Double.parseDouble(weatherDataEntity.getWindSpeed()));
-        PressureMeasurement pressureMeasurement = weatherDataEntity.getPressure().equals("") ? null : new PressureMeasurement(Double.parseDouble(weatherDataEntity.getPressure()));
-        RainfallMeasurement rainfallMeasurement = weatherDataEntity.getRainfallInPastHour().equals("") ? null : new RainfallMeasurement(Double.parseDouble(weatherDataEntity.getRainfallInPastHour()));
+        String temperature = weatherDataEntity.getTemperature();
+        TemperatureMeasurement temperatureMeasurement = (temperature == null || temperature.equals("")) ? null : new TemperatureMeasurement(Double.parseDouble(temperature));
+
+        String humidity = weatherDataEntity.getHumidity();
+        HumidityMeasurement humidityMeasurement = (humidity == null || humidity.equals("")) ? null : new HumidityMeasurement(Double.parseDouble(humidity));
+
+        String windDirection = weatherDataEntity.getWindDirection();
+        WindDirectionMeasurement windDirectionMeasurement = (windDirection == null || windDirection.equals("")) ? null : new WindDirectionMeasurement(windDirection);
+
+        String windSpeed = weatherDataEntity.getWindSpeed();
+        WindSpeedMeasurement windSpeedMeasurement = (windSpeed == null || windSpeed.equals("")) ? null : new WindSpeedMeasurement(Double.parseDouble(windSpeed));
+
+        String pressure = weatherDataEntity.getPressure();
+        PressureMeasurement pressureMeasurement = (pressure == null || pressure.equals("")) ? null : new PressureMeasurement(Double.parseDouble(pressure));
+
+        String rainfall = weatherDataEntity.getRainfallInPastHour();
+        RainfallMeasurement rainfallMeasurement = (rainfall == null || rainfall.equals("")) ? null : new RainfallMeasurement(Double.parseDouble(rainfall));
 
         return new WeatherDataPoint(temperatureMeasurement, humidityMeasurement, windDirectionMeasurement, windSpeedMeasurement, pressureMeasurement, rainfallMeasurement);
     }

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/entities/AirDataEntity.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/entities/AirDataEntity.java
@@ -1,6 +1,5 @@
 package uk.ac.cam.alpha2017.airqualityradar.backend.data.entities;
 
-import com.microsoft.azure.storage.table.StoreAs;
 import com.microsoft.azure.storage.table.TableServiceEntity;
 
 /**
@@ -9,102 +8,63 @@ import com.microsoft.azure.storage.table.TableServiceEntity;
 public class AirDataEntity extends TableServiceEntity implements Comparable {
 
     private String searchTimestamp;
-    private String year;
-    private String daysSinceStartOfYear;
-    private String minutesPastMidnight;
+    private Integer year;
+    private Integer daysSinceStartOfYear;
+    private Integer minutesPastMidnight;
     private Long latitude;
     private Long longitude;
-    private String NOx;
-    private String PM10;
-    private String PM25;
+    private Double NOx;
+    private Double PM10;
+    private Double PM25;
 
-    @StoreAs(name = AirDataEntityColumns.SEARCH_TIMESTAMP)
-    public void setSearchTimestamp(String searchTimestamp) {
+    public AirDataEntity() {}
+
+    public AirDataEntity(String partitionKey, String rowKey, String searchTimestamp, Integer year, Integer daysSinceStartOfYear, Integer minutesPastMidnight, Long latitude, Long longitude, Double NOx, Double PM10, Double PM25) {
+        super(partitionKey, rowKey);
         this.searchTimestamp = searchTimestamp;
-    }
-
-    @StoreAs(name = AirDataEntityColumns.YEAR)
-    public void setYear(String year) {
         this.year = year;
-    }
-
-    @StoreAs(name = AirDataEntityColumns.DAYS)
-    public void setDaysSinceStartOfYear(String daysSinceStartOfYear) {
         this.daysSinceStartOfYear = daysSinceStartOfYear;
-    }
-
-    @StoreAs(name = AirDataEntityColumns.MINUTES)
-    public void setMinutesPastMidnight(String minutesPastMidnight) {
         this.minutesPastMidnight = minutesPastMidnight;
-    }
-
-    @StoreAs(name = AirDataEntityColumns.LATITUDE)
-    public void setLatitude(Long latitude) {
         this.latitude = latitude;
-    }
-
-    @StoreAs(name = AirDataEntityColumns.LONGITUDE)
-    public void setLongitude(Long Longitude) {
-        this.longitude = Longitude;
-    }
-
-    @StoreAs(name = AirDataEntityColumns.NOX)
-    public void setNOx(String NOx) {
+        this.longitude = longitude;
         this.NOx = NOx;
-    }
-
-    @StoreAs(name = AirDataEntityColumns.PM10)
-    public void setPM10(String PM10) {
         this.PM10 = PM10;
-    }
-
-    @StoreAs(name = AirDataEntityColumns.PM25)
-    public void setPM25(String PM25) {
         this.PM25 = PM25;
     }
 
-    @StoreAs(name = AirDataEntityColumns.SEARCH_TIMESTAMP)
     public String getSearchTimestamp() {
         return searchTimestamp;
     }
 
-    @StoreAs(name = AirDataEntityColumns.YEAR)
-    public String getYear() {
+    public Integer getYear() {
         return year;
     }
 
-    @StoreAs(name = AirDataEntityColumns.DAYS)
-    public String getDaysSinceStartOfYear() {
+    public Integer getDaysSinceStartOfYear() {
         return daysSinceStartOfYear;
     }
 
-    @StoreAs(name = AirDataEntityColumns.MINUTES)
-    public String getMinutesPastMidnight() {
+    public Integer getMinutesPastMidnight() {
         return minutesPastMidnight;
     }
 
-    @StoreAs(name = AirDataEntityColumns.LATITUDE)
     public Long getLatitude() {
         return latitude;
     }
 
-    @StoreAs(name = AirDataEntityColumns.LONGITUDE)
     public Long getLongitude() {
         return longitude;
     }
 
-    @StoreAs(name = AirDataEntityColumns.NOX)
-    public String getNOx() {
+    public Double getNOx() {
         return NOx;
     }
 
-    @StoreAs(name = AirDataEntityColumns.PM10)
-    public String getPM10() {
+    public Double getPM10() {
         return PM10;
     }
 
-    @StoreAs(name = AirDataEntityColumns.PM25)
-    public String getPM25() {
+    public Double getPM25() {
         return PM25;
     }
 

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/entities/AirDataEntityResolver.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/data/entities/AirDataEntityResolver.java
@@ -1,0 +1,31 @@
+package uk.ac.cam.alpha2017.airqualityradar.backend.data.entities;
+
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.table.EntityProperty;
+import com.microsoft.azure.storage.table.EntityResolver;
+
+import java.util.Date;
+import java.util.HashMap;
+
+public class AirDataEntityResolver implements EntityResolver<AirDataEntity> {
+    @Override
+    public AirDataEntity resolve(String partitionKey, String rowKey, Date timeStamp, HashMap<String, EntityProperty> properties, String etag) throws StorageException {
+        EntityProperty nox = properties.get(AirDataEntityColumns.NOX);
+        EntityProperty pm10 = properties.get(AirDataEntityColumns.PM10);
+        EntityProperty pm25 = properties.get(AirDataEntityColumns.PM25);
+
+        return new AirDataEntity(
+                partitionKey,
+                rowKey,
+                properties.get(AirDataEntityColumns.SEARCH_TIMESTAMP).getValueAsString(),
+                properties.get(AirDataEntityColumns.YEAR).getValueAsInteger(),
+                properties.get(AirDataEntityColumns.DAYS).getValueAsInteger(),
+                properties.get(AirDataEntityColumns.MINUTES).getValueAsInteger(),
+                properties.get(AirDataEntityColumns.LATITUDE).getValueAsLong(),
+                properties.get(AirDataEntityColumns.LONGITUDE).getValueAsLong(),
+                nox.getValueAsString().equals("") ? null : nox.getValueAsDouble(),
+                pm10.getValueAsString().equals("") ? null : pm10.getValueAsDouble(),
+                pm25.getValueAsString().equals("") ? null : pm25.getValueAsDouble()
+        );
+    }
+}

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/models/DataPoint.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/models/DataPoint.java
@@ -7,12 +7,14 @@ public class DataPoint {
     private Location location;
     private AirDataPoint air;
     private WeatherDataPoint weather;
+    private boolean isPredicted;
 
-    public DataPoint(Calendar calendar, Location location, AirDataPoint air, WeatherDataPoint weather) {
+    public DataPoint(Calendar calendar, Location location, AirDataPoint air, WeatherDataPoint weather, boolean isPredicted) {
         this.calendar = calendar;
         this.location = location;
         this.air = air;
         this.weather = weather;
+        this.isPredicted = isPredicted;
     }
 
     public Calendar getCalendar() {
@@ -29,5 +31,9 @@ public class DataPoint {
 
     public WeatherDataPoint getWeather() {
         return weather;
+    }
+
+    public boolean isPredicted() {
+        return isPredicted;
     }
 }

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/services/MockRadarDataService.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/services/MockRadarDataService.java
@@ -92,7 +92,7 @@ public class MockRadarDataService implements DataService {
                 PM25Measurement pm25 = new PM25Measurement(ThreadLocalRandom.current().nextDouble(50, 600));
                 AirDataPoint airDataPoint = new AirDataPoint(nox, pm10, pm25);
 
-                dataPoints.add(new DataPoint(sampleCalendar, sampleLocation, airDataPoint, weatherDataPoint));
+                dataPoints.add(new DataPoint(sampleCalendar, sampleLocation, airDataPoint, weatherDataPoint, false));
             }
         }
 

--- a/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/services/RadarDataService.java
+++ b/src/main/java/uk/ac/cam/alpha2017/airqualityradar/backend/services/RadarDataService.java
@@ -2,6 +2,7 @@ package uk.ac.cam.alpha2017.airqualityradar.backend.services;
 
 import com.microsoft.azure.storage.StorageException;
 import uk.ac.cam.alpha2017.airqualityradar.backend.data.HistoricalDataProvider;
+import uk.ac.cam.alpha2017.airqualityradar.backend.data.PredictionsDataProvider;
 import uk.ac.cam.alpha2017.airqualityradar.backend.data.azureconnectors.TableDoesNotExistException;
 import uk.ac.cam.alpha2017.airqualityradar.backend.models.DataPoint;
 
@@ -13,22 +14,39 @@ import java.util.List;
 public class RadarDataService implements DataService {
 
     private final HistoricalDataProvider historicalDataProvider;
+    private final PredictionsDataProvider predictionsDataProvider;
 
-    public RadarDataService(HistoricalDataProvider historicalDataProvider) {
+    public RadarDataService(HistoricalDataProvider historicalDataProvider, PredictionsDataProvider predictionsDataProvider) {
         this.historicalDataProvider = historicalDataProvider;
+        this.predictionsDataProvider = predictionsDataProvider;
     }
 
     public List<DataPoint> getDataPoints(Calendar calendar) {
-        // We only have historical data at the moment, so show the past 3 days
+        // Past three days
         Calendar fromCalendar = (Calendar)calendar.clone();
         fromCalendar.add(Calendar.DATE, -3);
+
+        // Next three days
+        Calendar toCalendar = (Calendar)calendar.clone();
+        toCalendar.add(Calendar.DATE, 4);
 
         List<DataPoint> dataPoints;
 
         try {
-            dataPoints = this.historicalDataProvider.getDataPoints(fromCalendar, calendar);
+            dataPoints = this.historicalDataProvider.getDataPoints(fromCalendar, toCalendar);
         } catch (StorageException | InvalidKeyException | URISyntaxException | TableDoesNotExistException e) {
             throw new RuntimeException("Failed to retrieve data from historical data provider");
+        }
+
+        if (dataPoints.size() > 0) {
+            DataPoint lastDataPoint = dataPoints.get(dataPoints.size() - 1);
+            fromCalendar = lastDataPoint.getCalendar();
+        }
+
+        try {
+            dataPoints.addAll(this.predictionsDataProvider.getDataPoints(fromCalendar, toCalendar));
+        } catch (StorageException | InvalidKeyException | URISyntaxException | TableDoesNotExistException e) {
+            throw new RuntimeException("Failed to retrieve data from predictions data provider");
         }
 
         return dataPoints;


### PR DESCRIPTION
This change introduces a PredictionsDataProvider to provide predictions to the service layer, as well as:

- An AbstractDataProvider to handle common functionality between predictions and historical data
- An updated RadarDataService to provide the predictions to the API controller
- An EntityResolver to handle mismatches between types in the table